### PR TITLE
feat: implement split expense grouping functionality

### DIFF
--- a/apps/fyle/models.py
+++ b/apps/fyle/models.py
@@ -14,7 +14,7 @@ from django.db.models import Count, JSONField
 from fyle_accounting_mappings.models import ExpenseAttribute
 
 from apps.fyle.enums import ExpenseStateEnum, FundSourceEnum, PlatformExpensesEnum
-from apps.workspaces.models import Workspace
+from apps.workspaces.models import Workspace, WorkspaceGeneralSettings
 
 logger = logging.getLogger(__name__)
 logger.level = logging.INFO
@@ -35,6 +35,7 @@ ALLOWED_FIELDS = [
     "spent_at",
     "expense_id",
     "posted_at",
+    "bank_transaction_id",
 ]
 
 
@@ -515,13 +516,52 @@ class ExpenseGroup(models.Model):
         corporate_credit_card_expenses = list(
             filter(lambda expense: expense.fund_source == "CCC", expense_objects)
         )
-        corporate_credit_card_expense_groups = _group_expenses(
-            corporate_credit_card_expenses,
-            corporate_credit_card_expense_group_field,
-            workspace_id,
-        )
 
-        expense_groups.extend(corporate_credit_card_expense_groups)
+        if corporate_credit_card_expenses:
+            workspace_general_settings = WorkspaceGeneralSettings.objects.get(
+                workspace_id=workspace_id
+            )
+            ccc_export_module = workspace_general_settings.corporate_credit_card_expenses_object
+
+            if ccc_export_module == "BANK TRANSACTION" and expense_group_settings.split_expense_grouping == 'MULTIPLE_LINE_ITEM':
+                ccc_expenses_without_bank_transaction_id = list(
+                    filter(lambda expense: not expense.bank_transaction_id, corporate_credit_card_expenses)
+                )
+
+                ccc_expenses_with_bank_transaction_id = list(
+                    filter(lambda expense: expense.bank_transaction_id, corporate_credit_card_expenses)
+                )
+
+                if ccc_expenses_without_bank_transaction_id:
+                    groups_without_bank_transaction_id = _group_expenses(
+                        ccc_expenses_without_bank_transaction_id,
+                        corporate_credit_card_expense_group_field,
+                        workspace_id,
+                    )
+                    expense_groups.extend(groups_without_bank_transaction_id)
+
+                if ccc_expenses_with_bank_transaction_id:
+                    split_expense_group_fields = [
+                        field for field in corporate_credit_card_expense_group_field
+                        if field not in ('spent_at', 'posted_at', 'expense_id')
+                    ]
+                    split_expense_group_fields.append('bank_transaction_id')
+
+                    groups_with_bank_transaction_id = _group_expenses(
+                        ccc_expenses_with_bank_transaction_id,
+                        split_expense_group_fields,
+                        workspace_id,
+                    )
+                    expense_groups.extend(groups_with_bank_transaction_id)
+
+            else:
+                corporate_credit_card_expense_groups = _group_expenses(
+                    corporate_credit_card_expenses,
+                    corporate_credit_card_expense_group_field,
+                    workspace_id,
+                )
+
+                expense_groups.extend(corporate_credit_card_expense_groups)
 
         expense_group_objects = []
 

--- a/apps/fyle/models.py
+++ b/apps/fyle/models.py
@@ -543,7 +543,7 @@ class ExpenseGroup(models.Model):
                 if ccc_expenses_with_bank_transaction_id:
                     split_expense_group_fields = [
                         field for field in corporate_credit_card_expense_group_field
-                        if field not in ('spent_at', 'posted_at', 'expense_id')
+                        if field not in ('expense_id', 'expense_number')
                     ]
                     split_expense_group_fields.append('bank_transaction_id')
 

--- a/sql/scripts/027-default-split-expense-grouping-for-old-orgs.sql
+++ b/sql/scripts/027-default-split-expense-grouping-for-old-orgs.sql
@@ -1,0 +1,5 @@
+rollback;
+begin;
+
+UPDATE expense_group_settings
+SET split_expense_grouping = 'SINGLE_LINE_ITEM';


### PR DESCRIPTION
## Old behaviour

- Fetch reimbursable and ccc expenses from Fyle
- Group reimbursable expenses based on `reimbursable_expense_group_fields`
- Group CCC expenses based on `corporate_credit_card_expense_group_fields`

## New behaviour

- Fetch reimbursable and ccc expenses from Fyle
- Group reimbursable expenses based on `reimbursable_expense_group_fields`
- If ccc_export_type ≠ (CC Charge | Bank transactions) or `split_expense_grouping` == `SINGLE_LINE_ITEM`
    - Continue old flow using `corporate_credit_card_expense_group_fields`
- Else
    - Maintain 2 lists, `ccc_expenses_without_bank_transaction`, `ccc_expenses_with_bank_transaction` (filter by `bank_transaction_id` key)
    - Continue old flow for `ccc_expenses_without_bank_transaction`
    - For `ccc_expenses_with_bank_transaction` →
        - Do **NOT** group by `spent_at`, `posted_at` or `expense_id`
        - Group by `bank_transaction_id` instead.

# Clickup
https://app.clickup.com/t/86cx084b8