### PR TITLE
feat: add script for split expense grouping 

### DIFF
--- a/sql/scripts/027-default-split-expense-grouping-for-old-orgs.sql
+++ b/sql/scripts/027-default-split-expense-grouping-for-old-orgs.sql
@@ -1,0 +1,5 @@
+rollback;
+begin;
+
+UPDATE expense_group_settings
+SET split_expense_grouping = 'SINGLE_LINE_ITEM';


### PR DESCRIPTION
Set the default split expense grouping config to `SINGLE_LINE_ITEM` for all existing orgs

# Clickup
https://app.clickup.com/t/86cx0vjb5