### PR TITLE
fix: Update re_export_stuck_exports to filter tasks older than 7 days

### DIFF
--- a/apps/internal/tasks.py
+++ b/apps/internal/tasks.py
@@ -22,6 +22,7 @@ def re_export_stuck_exports():
     task_logs = TaskLog.objects.filter(
         status__in=['ENQUEUED', 'IN_PROGRESS'],
         updated_at__lt=datetime.now() - timedelta(minutes=60),
+        updated_at__gt=datetime.now() - timedelta(days=7),
         expense_group_id__isnull=False,
         workspace_id__in=prod_workspace_ids
     )


### PR DESCRIPTION
### Description
- Added a condition to filter task logs that are older than 7 days, improving the accuracy of the re-export process for stuck exports.

## Clickup
https://app.clickup.com/